### PR TITLE
Do some cleanup

### DIFF
--- a/Boltdir/inventory.yaml
+++ b/Boltdir/inventory.yaml
@@ -7,28 +7,41 @@ config:
     run-as: root
     tty: true
 groups:
-  - name: local
-    targets: localhost
-    config:
-      transport: local
   - name: pe_adm_nodes
     targets:
       - _plugin: terraform
         dir: ext/terraform/google_pe_arch
         resource_type: google_compute_instance.master
         target_mapping:
-          uri: network_interface.0.access_config.0.nat_ip
           name: metadata.internalDNS
+          uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
         dir: ext/terraform/google_pe_arch
         resource_type: google_compute_instance.compiler
         target_mapping:
-          uri: network_interface.0.access_config.0.nat_ip
           name: metadata.internalDNS
+          uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
         dir: ext/terraform/google_pe_arch
         resource_type: google_compute_instance.psql
         target_mapping:
-          uri: network_interface.0.access_config.0.nat_ip
           name: metadata.internalDNS
-
+          uri: network_interface.0.access_config.0.nat_ip
+      - _plugin: terraform
+        dir: ext/terraform/aws_pe_arch
+        resource_type: aws_instance.master
+        target_mapping:
+          name: public_dns
+          uri: public_ip
+      - _plugin: terraform
+        dir: ext/terraform/aws_pe_arch
+        resource_type: aws_instance.compiler
+        target_mapping:
+          name: public_dns
+          uri: public_ip
+      - _plugin: terraform
+        dir: ext/terraform/aws_pe_arch
+        resource_type: aws_instance.psql
+        target_mapping:
+          name: public_dns
+          uri: public_ip

--- a/Boltdir/site-modules/autope/plans/destroy.pp
+++ b/Boltdir/site-modules/autope/plans/destroy.pp
@@ -5,21 +5,14 @@ plan autope::destroy(
   Enum['google', 'aws']   $provider         = 'google'
 ) {
 
+  Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
+
   $tf_dir = "ext/terraform/${provider}_pe_arch"
 
   if $provider == 'aws' {
     waring('AWS provider is currently expiremental and may change in a future release')
   }
 
-  # Mapping all the plan parameters to their corresponding Terraform vars,
-  # choosing to maintain a mirrored list so I can leverage the flexibility
-  # of Puppet expressions, typing, and documentation
-  #
-  # Converting Array typed parameters to Strings to prevent HEREDOC from
-  # stripping quotes and ensuring the quotes used are " instead of ', which are
-  # both required to exist in the tfvars file. Attempted to use a type
-  # conversion formatter instead of regsubst() but couldn't get it to work and
-  # docs are sparse on how it's suppose to work
   $vars_template = @(TFVARS)
     <% unless $project == undef { -%>
     project        = "<%= $project %>"
@@ -30,11 +23,6 @@ plan autope::destroy(
 
   $tfvars = inline_epp($vars_template)
 
-  # Creating an on-disk tfvars file to be used by Terraform::Apply to avoid a
-  # shell escaping issue I couldn't pin down in a reasonable amount of time
-  #
-  # with_tempfile_containing() custom function suggestion by Cas is brilliant
-  # for this, works perfectly
   autope::with_tempfile_containing('', $tfvars, '.tfvars') |$tfvars_file| {
     # Stands up our cloud infrastructure that we'll install PE onto, returning a
     # specific set of data via TF outputs that if replicated will make this plan

--- a/Boltdir/site-modules/autope/plans/upgrade.pp
+++ b/Boltdir/site-modules/autope/plans/upgrade.pp
@@ -6,6 +6,8 @@ plan autope::upgrade(
   Enum['google', 'aws']                $provider         = 'google'
 ) {
 
+  Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
+
   $tf_dir = "ext/terraform/${provider}_pe_arch"
 
   if $provider == 'aws' {


### PR DESCRIPTION
	Adds a little more documentation to primary plan, removes
	duplicated comments from other plans, adds entries to inventory
	file for AWS based deployments, and moves localhost transport
	configuration into the plan to accomplish a simpler inventory
	file