### PR TITLE
Deploy TF modules to .terraform

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -24,10 +24,10 @@ mod 'puppetlabs-peadm',
 #
 mod 'terraform-google_pe_arch',
     git:          'https://github.com/puppetlabs/terraform-google-pe_arch.git',
-    ref:          'a16548026ef466cb782dee1ee5e75b05cef9e1bd',
-    install_path: 'ext/terraform'
+    ref:          '9c544ba3a126e265f6a4832d37096f4719d996a6',
+    install_path: '.terraform'
 
 mod 'terraform-aws_pe_arch',
    git:          'https://github.com/puppetlabs/terraform-aws-pe_arch.git',
    ref:          'bbf10d9708c5b1876b22b586984ab55688e173ad',
-   install_path: 'ext/terraform'
+   install_path: '.terraform'

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -8,37 +8,37 @@ groups:
   - name: peadm_nodes
     targets:
       - _plugin: terraform
-        dir: ext/terraform/google_pe_arch
+        dir: .terraform/google_pe_arch
         resource_type: google_compute_instance.server
         target_mapping:
           name: metadata.internalDNS
           uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
-        dir: ext/terraform/google_pe_arch
+        dir: .terraform/google_pe_arch
         resource_type: google_compute_instance.compiler
         target_mapping:
           name: metadata.internalDNS
           uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
-        dir: ext/terraform/google_pe_arch
+        dir: .terraform/google_pe_arch
         resource_type: google_compute_instance.psql
         target_mapping:
           name: metadata.internalDNS
           uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
-        dir: ext/terraform/aws_pe_arch
+        dir: .terraform/aws_pe_arch
         resource_type: aws_instance.server
         target_mapping:
           name: public_dns
           uri: public_ip
       - _plugin: terraform
-        dir: ext/terraform/aws_pe_arch
+        dir: .terraform/aws_pe_arch
         resource_type: aws_instance.compiler
         target_mapping:
           name: public_dns
           uri: public_ip
       - _plugin: terraform
-        dir: ext/terraform/aws_pe_arch
+        dir: .terraform/aws_pe_arch
         resource_type: aws_instance.psql
         target_mapping:
           name: public_dns
@@ -46,13 +46,13 @@ groups:
   - name: agent_nodes
     targets:
       - _plugin: terraform
-        dir: ext/terraform/google_pe_arch
+        dir: .terraform/google_pe_arch
         resource_type: google_compute_instance.node
         target_mapping:
           name: metadata.internalDNS
           uri: network_interface.0.access_config.0.nat_ip
       - _plugin: terraform
-        dir: ext/terraform/aws_pe_arch
+        dir: .terraform/aws_pe_arch
         resource_type: aws_instance.node
         target_mapping:
           name: public_dns

--- a/plans/destroy.pp
+++ b/plans/destroy.pp
@@ -8,7 +8,7 @@ plan autope::destroy(
 
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
 
-  $tf_dir = "ext/terraform/${provider}_pe_arch"
+  $tf_dir = ".terraform/${provider}_pe_arch"
 
   $vars_template = @(TFVARS)
     <% unless $project == undef { -%>

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -24,7 +24,7 @@ plan autope(
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
 
   # Where r10k deploys our various Terraform modules for each cloud provider
-  $tf_dir = "ext/terraform/${provider}_pe_arch"
+  $tf_dir = ".terraform/${provider}_pe_arch"
 
   # Ensure the Terraform project directory has been initialized ahead of
   # attempting an apply

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -8,7 +8,7 @@ plan autope::upgrade(
 
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
 
-  $tf_dir = "ext/terraform/${provider}_pe_arch"
+  $tf_dir = ".terraform/${provider}_pe_arch"
 
   if $provider == 'aws' {
     waring('AWS provider is currently expiremental and may change in a future release')


### PR DESCRIPTION
Adopts a similar convention to where Puppet modules are stored. GCP
Terraform module updated with new SHA to point at a version with minor
bug fix.