### PR TITLE
(SOLARCH-523) the name entries should be internal cloud names for pup…

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -109,7 +109,7 @@ plan autope(
             'uri'  => 'network_interface.0.access_config.0.nat_ip',
           },
           'aws' => {
-            'name' => 'public_dns',
+            'name' => 'private_dns',
             'uri'  => 'public_ip',
           }
         }

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -39,7 +39,7 @@ plan autope::upgrade(
             'uri'  => 'network_interface.0.access_config.0.nat_ip',
           },
           'aws' => {
-            'name' => 'public_dns',
+            'name' => 'private_dns',
             'uri'  => 'public_ip',
           }
         }


### PR DESCRIPTION
Updated public to private to make sure puppet uses internal dns references rather than public.

Tested with 

`/opt/puppetlabs/bolt/bin/bolt plan run autope project=davidsand ssh_user=centos provider=aws architecture=xlarge replica=true node_count=3 compiler_count=4 firewall_allow='[ "0.0.0.0/0" ]'`

All ran correctly as per output and tested node runs and web interface successfully

`Starting: plan autope
Starting: task terraform::initialize on localhost
Finished: task terraform::initialize with 0 failures in 0.22 sec
Starting: plan terraform::apply
Starting: task terraform::apply on localhost
Finished: task terraform::apply with 0 failures in 248.69 sec
Starting: task terraform::output on localhost
Finished: task terraform::output with 0 failures in 0.9 sec
Finished: plan terraform::apply in 4 min, 10 sec
Starting: plan peadm::install
Starting: plan peadm::subplans::install
Starting: task peadm::precheck on 8 targets
Finished: task peadm::precheck with 0 failures in 7.05 sec
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-p74im2 to /tmp/pe.conf on ip-10-138-1-186.us-west-2.compute.internal
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-41gk6f to /tmp/pe.conf on ip-10-138-1-184.us-west-2.compute.internal
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-1jhjnlu to /tmp/pe.conf on ip-10-138-2-45.us-west-2.compute.internal
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-1jhjnlu to /tmp/pe.conf with 0 failures in 5.53 sec
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-p74im2 to /tmp/pe.conf with 0 failures in 5.55 sec
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-78809-41gk6f to /tmp/pe.conf with 0 failures in 5.67 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-186.us-west-2.compute.internal
Starting: task peadm::mkdir_p_file on ip-10-138-1-184.us-west-2.compute.internal
Starting: task peadm::mkdir_p_file on ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 5.97 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.06 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.1 sec
Starting: task peadm::download on ip-10-138-1-186.us-west-2.compute.internal, ip-10-138-1-184.us-west-2.compute.internal, ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::download with 0 failures in 42.95 sec
Starting: plan peadm::util::insert_csr_extension_requests
Starting: plan peadm::util::insert_csr_extension_requests
Starting: plan peadm::util::insert_csr_extension_requests
Starting: task peadm::read_file on ip-10-138-1-186.us-west-2.compute.internal
Starting: task peadm::read_file on ip-10-138-1-184.us-west-2.compute.internal
Starting: task peadm::read_file on ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::read_file with 0 failures in 6.13 sec
Finished: task peadm::read_file with 0 failures in 6.2 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-184.us-west-2.compute.internal
Starting: task peadm::mkdir_p_file on ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::read_file with 0 failures in 6.56 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 5.92 sec
Finished: plan peadm::util::insert_csr_extension_requests in 12.59 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.08 sec
Finished: plan peadm::util::insert_csr_extension_requests in 13.11 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.08 sec
Finished: plan peadm::util::insert_csr_extension_requests in 13.62 sec
Starting: task peadm::pe_install on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::pe_install with 0 failures in 228.67 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 6.99 sec
Starting: task peadm::pe_install on ip-10-138-1-184.us-west-2.compute.internal, ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::pe_install with 0 failures in 91.35 sec
Starting: command 'systemctl stop pe-puppetdb' on ip-10-138-1-186.us-west-2.compute.internal
Finished: command 'systemctl stop pe-puppetdb' with 0 failures in 2.34 sec
Starting: command 'systemctl start pe-puppetdb' on ip-10-138-1-186.us-west-2.compute.internal
Finished: command 'systemctl start pe-puppetdb' with 0 failures in 30.52 sec
Starting: task peadm::rbac_token on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::rbac_token with 0 failures in 8.97 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 6.09 sec
Starting: task peadm::code_manager on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::code_manager with 0 failures in 11.89 sec
Starting: task peadm::puppet_runonce on ip-10-138-1-184.us-west-2.compute.internal, ip-10-138-2-45.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-1-178.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-2-193.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-3-207.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-4-252.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-2-135.us-west-2.compute.internal
Finished: task peadm::agent_install with 0 failures in 35.58 sec
Starting: task peadm::submit_csr on ip-10-138-4-252.us-west-2.compute.internal
Finished: task peadm::puppet_runonce with 0 failures in 39.0 sec
Finished: task peadm::agent_install with 0 failures in 39.52 sec
Starting: task peadm::submit_csr on ip-10-138-3-207.us-west-2.compute.internal
Finished: task peadm::agent_install with 0 failures in 40.23 sec
Starting: task peadm::submit_csr on ip-10-138-1-178.us-west-2.compute.internal
Finished: task peadm::agent_install with 0 failures in 40.85 sec
Starting: task peadm::submit_csr on ip-10-138-2-193.us-west-2.compute.internal
Finished: task peadm::agent_install with 0 failures in 44.02 sec
Starting: task peadm::submit_csr on ip-10-138-2-135.us-west-2.compute.internal
Finished: task peadm::submit_csr with 0 failures in 14.4 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::submit_csr with 0 failures in 16.3 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::submit_csr with 0 failures in 16.45 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 9.06 sec
Starting: task peadm::puppet_runonce on ip-10-138-4-252.us-west-2.compute.internal
Finished: task peadm::submit_csr with 0 failures in 18.25 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::submit_csr with 0 failures in 16.36 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 9.44 sec
Starting: task peadm::puppet_runonce on ip-10-138-1-178.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 10.4 sec
Starting: task peadm::puppet_runonce on ip-10-138-3-207.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 9.8 sec
Starting: task peadm::puppet_runonce on ip-10-138-2-193.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 9.84 sec
Starting: task peadm::puppet_runonce on ip-10-138-2-135.us-west-2.compute.internal
Finished: task peadm::puppet_runonce with 0 failures in 22.99 sec
Finished: task peadm::puppet_runonce with 0 failures in 146.79 sec
Finished: task peadm::puppet_runonce with 0 failures in 159.98 sec
Finished: task peadm::puppet_runonce with 0 failures in 167.93 sec
Finished: task peadm::puppet_runonce with 0 failures in 170.75 sec
Starting: task peadm::puppet_runonce on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::puppet_runonce with 0 failures in 79.12 sec
Starting: task peadm::wait_until_service_ready on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::wait_until_service_ready with 0 failures in 6.72 sec
Starting: task peadm::puppet_runonce on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::puppet_runonce with 0 failures in 55.2 sec
Starting: task peadm::mkdir_p_file on ip-10-138-1-186.us-west-2.compute.internal
Starting: task peadm::mkdir_p_file on ip-10-138-1-184.us-west-2.compute.internal
Starting: task peadm::mkdir_p_file on ip-10-138-2-45.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 6.35 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.39 sec
Finished: task peadm::mkdir_p_file with 0 failures in 7.07 sec
Finished: plan peadm::subplans::install in 14 min, 13 sec
Starting: plan peadm::subplans::configure
Starting: task peadm::read_file on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::read_file with 0 failures in 6.3 sec
Starting: task peadm::mkdir_p_file on ip-10-138-2-135.us-west-2.compute.internal, ip-10-138-1-178.us-west-2.compute.internal, ip-10-138-2-193.us-west-2.compute.internal, ip-10-138-3-207.us-west-2.compute.internal, ip-10-138-4-252.us-west-2.compute.internal
Finished: task peadm::mkdir_p_file with 0 failures in 6.94 sec
Starting: apply catalog on ip-10-138-1-186.us-west-2.compute.internal
Finished: apply catalog with 0 failures in 17.08 sec
Starting: task peadm::provision_replica on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::provision_replica with 0 failures in 741.15 sec
Starting: task peadm::puppet_runonce on 8 targets
Finished: task peadm::puppet_runonce with 0 failures in 69.15 sec
Starting: command 'systemctl start puppet' on 8 targets
Finished: command 'systemctl start puppet' with 0 failures in 2.52 sec
Finished: plan peadm::subplans::configure in 14 min, 3 sec
Finished: plan peadm::install in 28 min, 16 sec
Starting: task peadm::agent_install on ip-10-138-1-36.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-2-108.us-west-2.compute.internal
Starting: task peadm::agent_install on ip-10-138-3-88.us-west-2.compute.internal
Finished: task peadm::agent_install with 0 failures in 38.4 sec
Finished: task peadm::agent_install with 0 failures in 40.08 sec
Finished: task peadm::agent_install with 0 failures in 40.93 sec
Starting: task peadm::sign_csr on ip-10-138-1-186.us-west-2.compute.internal
Finished: task peadm::sign_csr with 0 failures in 9.2 sec
Log into Puppet Enterprise Console: https://54.212.169.162
Finished: plan autope in 33 min, 18 sec
Plan completed successfully with no result`

![Screenshot 2021-07-05 at 11 24 13](https://user-images.githubusercontent.com/77865779/124457375-a5613e80-dd83-11eb-9f5f-eda2a6ba87bd.png)
