### PR TITLE
Validate that autope works with Terraform v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@
 .DS_Store
 .project
 .envrc
+# List of files to ignore related to Bolt
+.modules/
+.plan_cache.json
+.resource_types/
+.task_cache.json
+.terraform/
+bolt-debug.log


### PR DESCRIPTION
While validating autope with Terraform v1, I found there are some files that are generated after running:

```
bolt module install --no-resolve
``` 

So in this PR I'm `git` ignoring these files generated by Bolt