### PR TITLE
[SOLARCH-525]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 .task_cache.json
 .terraform/
 bolt-debug.log
+.rerun.json

--- a/Puppetfile
+++ b/Puppetfile
@@ -24,15 +24,15 @@ mod 'puppetlabs-peadm',
 #
 mod 'terraform-google_pe_arch',
     git:          'https://github.com/puppetlabs/terraform-google-pe_arch.git',
-    ref:          'a565f0def8361dffc7858c7ca925780bb9a4d1d6',
+    ref:          '6ba3ebf69a0702435c776ad282ecef775f3be75f',
     install_path: '.terraform'
 
 mod 'terraform-aws_pe_arch',
     git:          'https://github.com/puppetlabs/terraform-aws-pe_arch.git',
-    ref:          'bbf10d9708c5b1876b22b586984ab55688e173ad',
+    ref:          'd37d7c0c2d7d15c51026d8a21d01a82a0f9536cb',
     install_path: '.terraform'
 
 mod 'terraform-azure_pe_arch',
     git:          'https://github.com/puppetlabs/terraform-azure-pe_arch.git',
-    ref:          '53b448153ffe8985919d15902c7f29376b48a6cb',
+    ref:          '6090257405546c214fe11c88512554c7c4ed6dab',
     install_path: '.terraform'

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,6 +6,7 @@ mod 'puppetlabs-apply_helpers', '0.2.1'
 mod 'puppetlabs-bolt_shim', '0.3.2'
 mod 'puppetlabs-terraform', '0.6.1'
 mod 'WhatsARanjit-node_manager', '0.7.5'
+mod 'nwops-debug', '0.2.0'
 
 # Modules from Git
 mod 'puppetlabs-peadm',

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,6 @@ mod 'puppetlabs-apply_helpers', '0.2.1'
 mod 'puppetlabs-bolt_shim', '0.3.2'
 mod 'puppetlabs-terraform', '0.6.1'
 mod 'WhatsARanjit-node_manager', '0.7.5'
-mod 'nwops-debug', '0.2.0'
 
 # Modules from Git
 mod 'puppetlabs-peadm',

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -126,12 +126,11 @@ plan autope(
   # Create and Target objects from our previously generated inventory and add
   # them to the peadm_nodes group and agent_nodes
   $inventory.each |$k, $v| { $v.each |$target| {
-    Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
-    wait_until_available($target['name'], wait_time => 300)
+    Target.new($target.merge($target_config)).add_to_group('new_nodes')
   }}
 
   $inventory['node'].each |$target| {
-    Target.new($target.merge($target_config)).add_to_group('agent_nodes')
+    Target.new($target.merge($target_config)).add_to_group('new_agent_nodes')
   }
 
   # Generate a parameters list to be fed to puppetlabs/peadm based on which
@@ -197,6 +196,8 @@ plan autope(
   $peadm_install_params = $params + $extra_peadm_params
   out::verbose("peadm::install params:\n\n${peadm_install_params.to_json_pretty}\n")
 
+  wait_until_available('new_nodes', wait_time => 300)
+
   unless $stage {
     # Once all the infrastructure data has been collected, handoff to puppetlabs/peadm
     run_plan('peadm::install', $params + $extra_peadm_params)
@@ -207,7 +208,7 @@ plan autope(
       # this issue from within Terraform but could not come up with clean solution
       # without further discovery, Bolt's a good hammer
       if $provider == 'aws' {
-        get_targets('agent_nodes').parallelize |$a| {
+        get_targets('new_agent_nodes').parallelize |$a| {
           run_task('peadm::agent_install', $a, {
             'server' => $apply['pool']['value'],
             'install_flags' => ["agent:certname=${a.name}"]
@@ -215,9 +216,9 @@ plan autope(
           )
         }
       } else {
-        run_task('peadm::agent_install', get_targets('agent_nodes'), { 'server' => $apply['pool']['value'] })
+        run_task('peadm::agent_install', get_targets('new_agent_nodes'), { 'server' => $apply['pool']['value'] })
       }
-      run_task('peadm::sign_csr', $inventory['server'][0]['name'], { 'certnames' => get_targets('agent_nodes').map |$a| { $a.name }  })
+      run_task('peadm::sign_csr', $inventory['server'][0]['name'], { 'certnames' => get_targets('new_agent_nodes').map |$a| { $a.name }  })
     }
   }
 

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -125,12 +125,12 @@ plan autope(
 
   # Create and Target objects from our previously generated inventory and add
   # them to the peadm_nodes group and agent_nodes
-  $inventory.each |$k, $v| { $v.each |$target| {
-    Target.new($target.merge($target_config)).add_to_group('new_nodes')
-  }}
+  $autope_targets = $inventory.map |$_, $v| { $v.map |$target| {
+    Target.new($target.merge($target_config))
+  }}.flatten
 
-  $inventory['node'].each |$target| {
-    Target.new($target.merge($target_config)).add_to_group('new_agent_nodes')
+  $agent_targets = $inventory['node'].map |$target| {
+    Target.new($target.merge($target_config))
   }
 
   # Generate a parameters list to be fed to puppetlabs/peadm based on which
@@ -196,7 +196,7 @@ plan autope(
   $peadm_install_params = $params + $extra_peadm_params
   out::verbose("peadm::install params:\n\n${peadm_install_params.to_json_pretty}\n")
 
-  wait_until_available('new_nodes', wait_time => 300)
+  wait_until_available($autope_targets, wait_time => 300)
 
   unless $stage {
     # Once all the infrastructure data has been collected, handoff to puppetlabs/peadm
@@ -208,7 +208,7 @@ plan autope(
       # this issue from within Terraform but could not come up with clean solution
       # without further discovery, Bolt's a good hammer
       if $provider == 'aws' {
-        get_targets('new_agent_nodes').parallelize |$a| {
+        parallelize($agent_targets) |$a| {
           run_task('peadm::agent_install', $a, {
             'server' => $apply['pool']['value'],
             'install_flags' => ["agent:certname=${a.name}"]
@@ -216,9 +216,9 @@ plan autope(
           )
         }
       } else {
-        run_task('peadm::agent_install', get_targets('new_agent_nodes'), { 'server' => $apply['pool']['value'] })
+        run_task('peadm::agent_install', $agent_targets, { 'server' => $apply['pool']['value'] })
       }
-      run_task('peadm::sign_csr', $inventory['server'][0]['name'], { 'certnames' => get_targets('new_agent_nodes').map |$a| { $a.name }  })
+      run_task('peadm::sign_csr', $inventory['server'][0]['name'], { 'certnames' => $agent_targets.map |$a| { $a.name }  })
     }
   }
 

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -127,6 +127,7 @@ plan autope(
   # them to the peadm_nodes group and agent_nodes
   $inventory.each |$k, $v| { $v.each |$target| {
     Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
+    wait_until_available($target['name'], wait_time => 300)
   }}
 
   $inventory['node'].each |$target| {


### PR DESCRIPTION
### Using Bolt's wait_until_available to check the connection with cloud instances

In this PR I'm using Bolt's `wait_until_available` function to establish a connection with the whole inventory (the one that comes from Terraform)

Previously we had this logic in the Terraform templates (see the referenced PRs below)

* Bonus = I'm adding the Puppet module `nwops-debug` for debugging purposes

----

**TODO after approval:** Once the PRs in the terraform templates are approved and merged, I need to update the Puppetfile with the new commit-sha