### PR TITLE
Fix non-functional autope::upgrade plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automatic Puppet Enterprise, a Bolt driven fusion of [puppetlabs/peadm](https://github.com/puppetlabs/puppetlabs-peadm) and Terraform.
 
-#### Table of Contents
+**Table of Contents**
 
 1. [Description](#description)
 2. [Setup - The basics of getting started with autope](#setup)
@@ -56,7 +56,7 @@ Types of things you'll be paying your cloud provider for
 * [Git Installed](https://git-scm.com/downloads)
 * [Terraform Installed](https://www.terraform.io/downloads.html)
 
-### Beginning with autope
+## Beginning with autope
 
 1. Clone this repository: `git clone https://github.com/puppetlabs/puppetlabs-autope.git && cd puppetlabs-autope`
 2. Install module dependencies: `bolt module install --no-resolve` (manually manages modules to take advantage of functionality that allows for additional content to be deployed that does not adhere to the Puppet Module packaging format, e.g. Terraform modules)
@@ -65,11 +65,11 @@ Types of things you'll be paying your cloud provider for
 
 ## Usage
 
-### Parameter requirments
+**Parameter requirements**
 
 Due to the creation of an elb load balancer (32 characters name limit) using the aws provider the project name can't be longer than 9 characters.
 
-### Example: params.json
+**Example: params.json**
 
 The command line will likely serve most uses of **autope** but if you wish to pass a longer list of IP blocks that are authorized to access your PE stack than creating a **params.json** file is going to be a good idea, instead of trying to type out a multi value array on the command line. The value that will ultimately be set for the GCP firewall will always include the internal network address space to ensure everything works no matter what is passed in by the user.
 
@@ -86,7 +86,9 @@ The command line will likely serve most uses of **autope** but if you wish to pa
 
 How to execute plan with **params.json**: `bolt plan run autope --params @params.json`
 
-### Example: deploy standard architecture on AWS with the developer role using a MFA enabled user
+### Deploying examples
+
+#### Deploy standard architecture on AWS with the developer role using a MFA enabled user
 
 This can also be used to deploy PE's large architecture without a fail over replica on AWS
 
@@ -105,17 +107,25 @@ $ ssh-add
 
 For more information about setting environment variables, please take a look at the detailed instructions on the [scripts/README](scripts/README.md) file
 
-### Example: destroy GCP stack
+### Destroying examples
+
+#### Destroy GCP stack
 
 The number of options required are reduced when destroying a stack
 
 `bolt plan run autope::destroy provider=google`
 
-### Example: destroy AWS stack
+#### Destroy AWS stack
 
 The number of options required are reduced when destroying a stack
 
 `bolt plan run autope::destroy provider=aws`
+
+### Upgrading examples
+
+#### Upgrade a AWS stack
+
+`bolt plan run autope::upgrade provider=aws ssh_user=centos version=2021.1.0`
 
 ## Limitations
 

--- a/functions/peadm_params_from_configuration.pp
+++ b/functions/peadm_params_from_configuration.pp
@@ -1,0 +1,23 @@
+# Generate a parameters list to be fed to puppetlabs/peadm based on which
+# architecture we've chosen to deploy. PEAdm will figure out the correct
+# thing to do based on whether or not there are valid values for each
+# architecture component. An empty array is equivalent to not defining the
+# parameter.
+
+function autope::peadm_params_from_configuration(
+  Hash $inventory,
+  String $compiler_pool_adress,
+  String $version,
+) >> Hash {
+  {
+    'primary_host'            => getvar('inventory.server.0.name'),
+    'primary_postgresql_host' => getvar('inventory.psql.0.name'),
+    'replica_host'            => getvar('inventory.server.1.name'),
+    'replica_postgresql_host' => getvar('inventory.psql.1.name'),
+    'compiler_hosts'          => getvar('inventory.compiler').map |$c| { $c['name'] },
+    'dns_alt_names'           => [ 'puppet', $compiler_pool_adress ],
+    'compiler_pool_address'   => $compiler_pool_adress,
+    'download_mode'           => 'direct',
+    'version'                 => $version
+  }
+}

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,9 +1,20 @@
 plan autope::upgrade(
-  TargetSpec                           $targets          = get_targets('peadm_nodes'),
-  String                               $version          = '2019.3.0',
-  String                               $ssh_user,
-  Enum['xlarge', 'large', 'standard']  $architecture     = 'xlarge',
-  Enum['google', 'aws', 'azure']       $provider         = 'google'
+  TargetSpec                           $targets             = get_targets('peadm_nodes'),
+  String                               $version             = '2019.3.0',
+  # String[1]                            $console_password    = 'puppetlabs',
+  Integer                              $compiler_count      = 1,
+  Optional[String[1]]                  $ssh_pub_key_file    = undef,
+  Optional[Integer]                    $node_count          = undef,
+  Optional[String[1]]                  $instance_image      = undef,
+  Optional[String[1]]                  $stack               = undef,
+  Array                                $firewall_allow      = [],
+  Hash                                 $extra_peadm_params  = {},
+  Boolean                              $replica             = false,
+  Enum['xlarge', 'large', 'standard']  $architecture        = 'standard',
+  Enum['google', 'aws', 'azure']       $provider            = 'aws',
+  String[1]                            $project             = $provider ? { 'aws' => 'ape', default => undef },
+  String[1]                            $ssh_user            = $provider ? { 'aws' => 'centos', default => undef },
+  String[1]                            $cloud_region        = $provider ? { 'azure' => 'westus2', 'aws' => 'us-west-2', default => 'us-west1' }, # lint:ignore:140chars
 ) {
 
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
@@ -11,8 +22,38 @@ plan autope::upgrade(
   $tf_dir = ".terraform/${provider}_pe_arch"
 
   if $provider == 'aws' {
-    waring('AWS provider is currently expiremental and may change in a future release')
+    warning('AWS provider is currently expiremental and may change in a future release')
   }
+
+  # WIP
+  $tfvars = inline_epp(@(TFVARS))
+    project        = "<%= $project %>"
+    user           = "<%= $ssh_user %>"
+    <% unless $ssh_pub_key_file == undef { -%>
+    ssh_key        = "<%= $ssh_pub_key_file %>"
+    <% } -%>
+    region         = "<%= $cloud_region %>"
+    compiler_count = <%= $compiler_count %>
+    <% unless $node_count == undef { -%>
+    node_count     = "<%= $node_count %>"
+    <% } -%>
+    <% unless $instance_image == undef { -%>
+    instance_image = "<%= $instance_image %>"
+    <% } -%>
+    <% unless stack == undef { -%>
+    stack_name     = "<%= $stack %>"
+    <% } -%>
+    firewall_allow = <%= String($firewall_allow).regsubst('\'', '"', 'G') %>
+    architecture   = "<%= $architecture %>"
+    replica        = <%= $replica %>
+    | TFVARS
+
+  # TODO: make this print only when user specifies --verbose
+  out::verbose(".tfvars file content:\n\n${tfvars}\n")
+
+  $terraform_output = run_task('terraform::output', 'localhost', dir => $tf_dir)
+  $applied = $terraform_output.first
+  #
 
   $target_config = {
     'config' => {
@@ -25,7 +66,7 @@ plan autope::upgrade(
     }
   }
 
-  $inventory = ['master', 'psql', 'compiler' ].reduce({}) |Hash $memo, String $i| {
+  $inventory = ['server', 'psql', 'compiler' ].reduce({}) |Hash $memo, String $i| {
     $memo + { $i => resolve_references({
         '_plugin'        => 'terraform',
         'dir'            => $tf_dir,
@@ -56,41 +97,52 @@ plan autope::upgrade(
     Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
   }}
 
+  # Debugging
+  # debug::break()
+
   case $architecture {
     'xlarge': {
       $params = {
-        'master_host'                    => $inventory['master'][0]['name'],
-        'master_replica_host'            => $inventory['master'][1]['name'],
-        'puppetdb_database_host'         => $inventory['psql'][0]['name'],
-        'puppetdb_database_replica_host' => $inventory['psql'][1]['name'],
+        'primary_host'                   => $inventory['server'][0]['name'],
+        'replica_host'                   => $inventory['server'][1]['name'],
+        'primary_postgresql_host'        => $inventory['psql'][0]['name'],
+        'replica_postgresql_host'        => $inventory['psql'][1]['name'],
         'compiler_hosts'                 => $inventory['compiler'].map |$c| { $c['name'] },
-        'console_password'               => $console_password,
-        'dns_alt_names'                  => [ 'puppet', $apply['pool']['value'] ],
-        'compiler_pool_address'          => $apply['pool']['value'],
-        'version'                        => $version
+        # 'console_password'               => $console_password,
+        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
+        'compiler_pool_address'          => $applied['pool']['value'],
+        'version'                        => $version,
+        'download_mode'                  => 'direct',
       }
     }
     'large': {
       $params = {
-        'master_host'                    => $inventory['master'][0]['name'],
+        'primary_host'                    => $inventory['server'][0]['name'],
         'compiler_hosts'                 => $inventory['compiler'].map |$c| { $c['name'] },
-        'console_password'               => $console_password,
-        'dns_alt_names'                  => [ 'puppet', $apply['pool']['value'] ],
-        'compiler_pool_address'          => $apply['pool']['value'],
-        'version'                        => $version
+        # 'console_password'               => $console_password,
+        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
+        'compiler_pool_address'          => $applied['pool']['value'],
+        'version'                        => $version,
+        'download_mode'                  => 'direct',
       }
     }
     'standard': {
       $params = {
-        'master_host'                    => $inventory['master'][0]['name'],
-        'console_password'               => $console_password,
-        'dns_alt_names'                  => [ 'puppet', $apply['pool']['value'] ],
-        'compiler_pool_address'          => $apply['pool']['value'],
-        'version'                        => $version
+        'primary_host'                    => $inventory['server'][0]['name'],
+        # 'console_password'               => $console_password,
+        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
+        'compiler_pool_address'          => $applied['pool']['value'],
+        'version'                        => $version,
+        'download_mode'                  => 'direct',
       }
     }
     default: { fail('Something went horribly wrong or only xlarge is supported in this configuration') }
   }
+
+  # Debugging
+  # debug::break()
+  # TODO: make this print only when user specifies --verbose
+  out::verbose("params var content:\n\n${params}\n")
 
   # Once all the infrastructure data has been collected, peadm takes over
   run_plan('peadm::upgrade', $params)

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -53,16 +53,8 @@ plan autope::upgrade(
     Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
   }}
 
-  $params = {
-    'primary_host'            => getvar('inventory.server.0.name'),
-    'primary_postgresql_host' => getvar('inventory.psql.0.name'),
-    'replica_host'            => getvar('inventory.server.1.name'),
-    'replica_postgresql_host' => getvar('inventory.psql.1.name'),
-    'compiler_hosts'          => getvar('inventory.compiler').map |$c| { $c['name'] },
-    'compiler_pool_address'   => $terraform_output['pool']['value'],
-    'download_mode'           => 'direct',
-    'version'                 => $version
-  }
+  $compiler_pool_adress = $terraform_output['pool']['value']
+  $params = autope::peadm_params_from_configuration($inventory, $compiler_pool_adress, $version)
 
   out::verbose("params var content:\n\n${params}\n")
 

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,59 +1,16 @@
 plan autope::upgrade(
-  TargetSpec                           $targets             = get_targets('peadm_nodes'),
-  String                               $version             = '2019.3.0',
-  # String[1]                            $console_password    = 'puppetlabs',
+  String                               $version             = '2021.0.0',
   Integer                              $compiler_count      = 1,
-  Optional[String[1]]                  $ssh_pub_key_file    = undef,
-  Optional[Integer]                    $node_count          = undef,
-  Optional[String[1]]                  $instance_image      = undef,
-  Optional[String[1]]                  $stack               = undef,
-  Array                                $firewall_allow      = [],
-  Hash                                 $extra_peadm_params  = {},
-  Boolean                              $replica             = false,
-  Enum['xlarge', 'large', 'standard']  $architecture        = 'standard',
   Enum['google', 'aws', 'azure']       $provider            = 'aws',
-  String[1]                            $project             = $provider ? { 'aws' => 'ape', default => undef },
   String[1]                            $ssh_user            = $provider ? { 'aws' => 'centos', default => undef },
-  String[1]                            $cloud_region        = $provider ? { 'azure' => 'westus2', 'aws' => 'us-west-2', default => 'us-west1' }, # lint:ignore:140chars
 ) {
 
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local'})
 
   $tf_dir = ".terraform/${provider}_pe_arch"
 
-  if $provider == 'aws' {
-    warning('AWS provider is currently expiremental and may change in a future release')
-  }
-
-  # WIP
-  $tfvars = inline_epp(@(TFVARS))
-    project        = "<%= $project %>"
-    user           = "<%= $ssh_user %>"
-    <% unless $ssh_pub_key_file == undef { -%>
-    ssh_key        = "<%= $ssh_pub_key_file %>"
-    <% } -%>
-    region         = "<%= $cloud_region %>"
-    compiler_count = <%= $compiler_count %>
-    <% unless $node_count == undef { -%>
-    node_count     = "<%= $node_count %>"
-    <% } -%>
-    <% unless $instance_image == undef { -%>
-    instance_image = "<%= $instance_image %>"
-    <% } -%>
-    <% unless stack == undef { -%>
-    stack_name     = "<%= $stack %>"
-    <% } -%>
-    firewall_allow = <%= String($firewall_allow).regsubst('\'', '"', 'G') %>
-    architecture   = "<%= $architecture %>"
-    replica        = <%= $replica %>
-    | TFVARS
-
-  # TODO: make this print only when user specifies --verbose
-  out::verbose(".tfvars file content:\n\n${tfvars}\n")
-
   $terraform_output = run_task('terraform::output', 'localhost', dir => $tf_dir)
   $applied = $terraform_output.first
-  #
 
   $target_config = {
     'config' => {
@@ -97,51 +54,17 @@ plan autope::upgrade(
     Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
   }}
 
-  # Debugging
-  # debug::break()
-
-  case $architecture {
-    'xlarge': {
-      $params = {
-        'primary_host'                   => $inventory['server'][0]['name'],
-        'replica_host'                   => $inventory['server'][1]['name'],
-        'primary_postgresql_host'        => $inventory['psql'][0]['name'],
-        'replica_postgresql_host'        => $inventory['psql'][1]['name'],
-        'compiler_hosts'                 => $inventory['compiler'].map |$c| { $c['name'] },
-        # 'console_password'               => $console_password,
-        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
-        'compiler_pool_address'          => $applied['pool']['value'],
-        'version'                        => $version,
-        'download_mode'                  => 'direct',
-      }
-    }
-    'large': {
-      $params = {
-        'primary_host'                    => $inventory['server'][0]['name'],
-        'compiler_hosts'                 => $inventory['compiler'].map |$c| { $c['name'] },
-        # 'console_password'               => $console_password,
-        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
-        'compiler_pool_address'          => $applied['pool']['value'],
-        'version'                        => $version,
-        'download_mode'                  => 'direct',
-      }
-    }
-    'standard': {
-      $params = {
-        'primary_host'                    => $inventory['server'][0]['name'],
-        # 'console_password'               => $console_password,
-        # 'dns_alt_names'                  => [ 'puppet', $applied['pool']['value'] ],
-        'compiler_pool_address'          => $applied['pool']['value'],
-        'version'                        => $version,
-        'download_mode'                  => 'direct',
-      }
-    }
-    default: { fail('Something went horribly wrong or only xlarge is supported in this configuration') }
+  $params = {
+    'primary_host'            => getvar('inventory.server.0.name'),
+    'primary_postgresql_host' => getvar('inventory.psql.0.name'),
+    'replica_host'            => getvar('inventory.server.1.name'),
+    'replica_postgresql_host' => getvar('inventory.psql.1.name'),
+    'compiler_hosts'          => getvar('inventory.compiler').map |$c| { $c['name'] },
+    'compiler_pool_address'   => $applied['pool']['value'],
+    'download_mode'           => 'direct',
+    'version'                 => $version
   }
 
-  # Debugging
-  # debug::break()
-  # TODO: make this print only when user specifies --verbose
   out::verbose("params var content:\n\n${params}\n")
 
   # Once all the infrastructure data has been collected, peadm takes over

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,7 +1,7 @@
 plan autope::upgrade(
-  String                               $version             = '2021.0.0',
+  String                               $version             = '2021.2.0',
   Integer                              $compiler_count      = 1,
-  Enum['google', 'aws', 'azure']       $provider            = 'aws',
+  Enum['google', 'aws', 'azure']       $provider,
   String[1]                            $ssh_user            = $provider ? { 'aws' => 'centos', default => undef },
 ) {
 
@@ -9,8 +9,7 @@ plan autope::upgrade(
 
   $tf_dir = ".terraform/${provider}_pe_arch"
 
-  $terraform_output = run_task('terraform::output', 'localhost', dir => $tf_dir)
-  $applied = $terraform_output.first
+  $terraform_output = run_task('terraform::output', 'localhost', dir => $tf_dir).first
 
   $target_config = {
     'config' => {
@@ -60,7 +59,7 @@ plan autope::upgrade(
     'replica_host'            => getvar('inventory.server.1.name'),
     'replica_postgresql_host' => getvar('inventory.psql.1.name'),
     'compiler_hosts'          => getvar('inventory.compiler').map |$c| { $c['name'] },
-    'compiler_pool_address'   => $applied['pool']['value'],
+    'compiler_pool_address'   => $terraform_output['pool']['value'],
     'download_mode'           => 'direct',
     'version'                 => $version
   }


### PR DESCRIPTION
### Fixing the upgrade plan

In this PR I adjusted the upgrade plan to:

1. Receive the correct parameters
2. and updated the parameters gathering logic (to pass to `peadm`)

Also as a **Bonus**, I updated the README file with a section about how to run the `autope::upgrade` plan (+ some markdown adjustments)

Thanks!